### PR TITLE
Update requirements to remove sklearn and shap since they are not needed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 mlflow>=2.0.0rc0
 pandas>=1.3.*
-scikit-learn>=1.1.*
 ipykernel>=6.12.*
 ipython>=7.32.*
-shap>=0.40.*


### PR DESCRIPTION
## What changes are proposed in this pull request?
Update requirements to remove sklearn and shap since they are not needed

## How is this patch tested?
- [x] Example repo doesn't need it as well
