### PR TITLE
Renaming estimator_spec to custom for training and custom_loader_method to loader_method for ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,11 +146,11 @@ One may specify multiple data locations by a list of locations as long as they h
 One of `parquet`, `spark_sql` and `delta`.  
 
 
-- `custom_loader_method`: string. Optional.  
+- `loader_method`: string. Optional.  
 Fully qualified name of the custom loader function.  
 <u>Example</u>: 
   ```
-  custom_loader_method: steps.ingest.load_file_as_dataframe
+  loader_method: steps.ingest.load_file_as_dataframe
   ```
 
 - `sql`: string. Required if format is `spark_sql`.  
@@ -264,7 +264,7 @@ using: automl/flaml
 
 Otherwise, if using a user-defined estimator function to train, specify:
 ```
-estimator_method: estimator_spec
+using: custom
 ```
 
 The user-defined estimator function should be written in [`steps/train.py`](https://github.com/mlflow/recipes-regression-template/blob/main/steps/train.py), 
@@ -275,7 +275,7 @@ and should return an unfitted estimator that is `sklearn`-compatible; that is, t
 <summary><strong><u>Full configuration reference</u></strong></summary>
 
 - `using`: string. Required.  
-`automl/flaml` if using AutoML to train or `estimator_spec` if using a user-defined estimator to train.
+`automl/flaml` if using AutoML to train or `custom` if using a user-defined estimator to train.
 
 - AutoML configuration reference
    - `time_budget_secs`: float. Optional.  

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -44,8 +44,8 @@ steps:
     transformer_method: steps.transform.transformer_fn
   train:
     #
-    # FIXME::REQUIRED: Specifies the method to use for training. Options are "automl/flaml" for 
-    #                  AutoML training or "estimator_spec" for user-defined estimators.
+    # FIXME::REQUIRED: Specifies the method to use for training. Options are "automl/flaml" for
+    #                  AutoML training or "custom" for user-defined estimators.
     using: ""
   evaluate:
     #


### PR DESCRIPTION
## What changes are proposed in this pull request?
Renaming estimator_spec to custom for training and custom_loader_method to loader_method for ingest

## How is this patch tested?
-[x] test passes

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [x] `area/regression`: Sklearn regression recipe example
- [ ] `area/build`: Build and test infrastructure for MLflow recipe example

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
